### PR TITLE
changed sciencebeam api path to /api

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository contains instructions for installing and configuring the `scienc
 It exposes:
 
 - `/` (Texture)
-- `/sciencebeam/api`
+- `/api`
 - `/grobid/`
 
 on port 443 and HTTPS (falls back to 80 and HTTP on Vagrant instances).

--- a/salt/sciencebeam-texture/config/etc-nginx-sites-enabled-sciencebeam-texture.conf
+++ b/salt/sciencebeam-texture/config/etc-nginx-sites-enabled-sciencebeam-texture.conf
@@ -4,8 +4,8 @@ server {
     listen      443 ssl;
     {% endif %}
 
-    location /sciencebeam/ {
-        proxy_pass http://localhost:8075/;
+    location /api/ {
+        proxy_pass http://localhost:8075/api/;
         proxy_buffering off;
     }
 

--- a/salt/sciencebeam-texture/config/home-deployuser-sciencebeam-texture-smoke_tests.sh
+++ b/salt/sciencebeam-texture/config/home-deployuser-sciencebeam-texture-smoke_tests.sh
@@ -10,7 +10,7 @@ smoke_url_ok localhost:8070/
 echo "Texture nginx"
 smoke_url_ok localhost/
 echo "Sciencebeam nginx"
-smoke_url_ok localhost/sciencebeam/api/
+smoke_url_ok localhost/api/
 echo "GROBID nginx"
 smoke_url_ok localhost/grobid/
 


### PR DESCRIPTION
Not sure if that matches the general setup, but it might be good to have the main (and probably only api, grobid does not need to be exposed) to be available under /api. (At least that is how I have it for PeerScout as well). Would you agree with that?