### PR TITLE
call npm run start:prod instead

### DIFF
--- a/salt/sciencebeam-texture/config/home-deployuser-sciencebeam-texture-docker-compose.yml
+++ b/salt/sciencebeam-texture/config/home-deployuser-sciencebeam-texture-docker-compose.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
     texture:
         image: elifesciences/sciencebeam_texture:${IMAGE_TAG}
-        command: npm start
+        command: npm run start:prod
         volumes:
             - data:/home/node/texture/data
         ports:


### PR DESCRIPTION
Need to change the startup command here as well (`npm start` is now for development mode).

Would be good to find a way that doesn't require two separate docker compose files or maybe it moving it to the main repo instead might also be better. Something to discuss..