### PR TITLE
added internal grobid network, preventing outbound connections

### DIFF
--- a/salt/sciencebeam-texture/config/etc-nginx-sites-enabled-sciencebeam-texture.conf
+++ b/salt/sciencebeam-texture/config/etc-nginx-sites-enabled-sciencebeam-texture.conf
@@ -10,11 +10,6 @@ server {
         proxy_buffering off;
     }
 
-    location /grobid/ {
-        proxy_pass http://localhost:8070/;
-        proxy_buffering off;
-    }
-
     location / {
         proxy_pass http://localhost:4000;
         proxy_buffering off;

--- a/salt/sciencebeam-texture/config/home-deployuser-sciencebeam-texture-docker-compose.yml
+++ b/salt/sciencebeam-texture/config/home-deployuser-sciencebeam-texture-docker-compose.yml
@@ -6,6 +6,8 @@ services:
         command: npm run start:prod
         ports:
             - "4000:4000"
+        depends_on:
+            - sciencebeam
     sciencebeam:
         image: elifesciences/sciencebeam:${SCIENCEBEAM_TAG}
         command: ./server.sh \
@@ -14,6 +16,9 @@ services:
             --grobid-action /processHeaderDocument
         ports:
             - "8075:8075"
+        networks:
+            - default
+            - grobid
         depends_on:
             - grobid
     grobid:
@@ -22,6 +27,11 @@ services:
             - JAVA_OPTS=-Xmx1g
         ports:
             - "8070:8070"
+        networks:
+            - grobid
 
-volumes:
-    data:
+networks:
+    default:
+        internal: false
+    grobid:
+        internal: true

--- a/salt/sciencebeam-texture/config/home-deployuser-sciencebeam-texture-smoke_tests.sh
+++ b/salt/sciencebeam-texture/config/home-deployuser-sciencebeam-texture-smoke_tests.sh
@@ -8,13 +8,9 @@ echo "Texture container"
 smoke_url_ok localhost:4000/
 echo "Sciencebeam container"
 smoke_url_ok localhost:8075/api/
-echo "GROBID container"
-smoke_url_ok localhost:8070/
 echo "Texture nginx"
 smoke_url_ok localhost/
 echo "Sciencebeam nginx"
 smoke_url_ok localhost/api/
-echo "GROBID nginx"
-smoke_url_ok localhost/grobid/
 
 smoke_report


### PR DESCRIPTION
Part of https://github.com/elifesciences/sciencebeam/issues/28

Slightly different approach since nginx is not part of the docker compose configuration.
Here, only the grobid container is on an internal network.
(I will update the local docker compose config to match this)