### PR TITLE
Always restart crashed containers

### DIFF
--- a/salt/sciencebeam-texture/config/home-deployuser-sciencebeam-texture-docker-compose.yml
+++ b/salt/sciencebeam-texture/config/home-deployuser-sciencebeam-texture-docker-compose.yml
@@ -30,6 +30,11 @@ services:
             - "8070:8070"
         networks:
             - grobid
+        healthcheck:
+            test: ["CMD", "bash", "-c", "echo > /dev/tcp/localhost/8070"]
+            interval: 10s
+            timeout: 10s
+            retries: 5
         restart: always
 
 networks:

--- a/salt/sciencebeam-texture/config/home-deployuser-sciencebeam-texture-docker-compose.yml
+++ b/salt/sciencebeam-texture/config/home-deployuser-sciencebeam-texture-docker-compose.yml
@@ -6,6 +6,7 @@ services:
         command: npm run start:prod
         ports:
             - "4000:4000"
+        restart: always
         depends_on:
             - sciencebeam
     sciencebeam:
@@ -18,6 +19,7 @@ services:
         networks:
             - default
             - grobid
+        restart: always
         depends_on:
             - grobid
     grobid:
@@ -28,6 +30,7 @@ services:
             - "8070:8070"
         networks:
             - grobid
+        restart: always
 
 networks:
     default:


### PR DESCRIPTION
Incidentally: on a reboot, restart containers that were stopped.

Fixes https://github.com/elifesciences/sciencebeam-texture/issues/25